### PR TITLE
Nasty fix for focus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ qt_add_qml_module(waycratelock
 target_link_libraries(waycratelock
   PRIVATE
   Qt6::Quick
+  Qt6::WaylandClientPrivate
   Qt6::WaylandClient
   Qt6::QuickControls2
   Qt6::Concurrent

--- a/qml/MainView.qml
+++ b/qml/MainView.qml
@@ -93,6 +93,7 @@ Page {
             }
 
             TextField {
+                objectName: "input"
                 id: input
                 visible: root.isIn && CommandLine.usePam
                 Layout.alignment: Qt.AlignHCenter


### PR DESCRIPTION
For the time being, this is a nasty fix for multiple window focus switch. 

Problem is that no one from Surface level report about different focus (for example have a look at [XdgSurface](https://codebrowser.dev/qt6/qtwayland/src/plugins/shellintegration/xdg-shell/qwaylandxdgshell.cpp.html#_ZN15QtWaylandClient18QWaylandXdgSurface8Toplevel14applyConfigureEv)) so the focus stays only in first window (as mentioned in README). As far as I looked, there is nothing can be done to correctly identify focus switch (wl_pointer is mostly closed, so no way to gather focus from there). So the only solution for now is to hook up onto QQuickItem(TextField) and call window focus handler ourselves.

This can be removed when Qt will do something about their surface policy: https://bugreports.qt.io/browse/QTBUG-120461