### PR TITLE
fix PAM and password input issue in the session lock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+# Makefile for WayCrateLock (Wrapper around CMakeLists.txt)
+
+BUILD_DIR = build
+CMAKE_FLAGS = -DCMAKE_INSTALL_PREFIX=/usr
+
+all: setup-pam build
+
+configure:
+	@mkdir -p $(BUILD_DIR)
+	@cd $(BUILD_DIR) && cmake $(CMAKE_FLAGS) ..
+
+build: configure
+	@cd $(BUILD_DIR) && make -j$(nproc)
+
+install: build
+	@cd $(BUILD_DIR) && sudo make install
+
+setup-pam:
+	@if [ ! -f /etc/pam.d/waycratelock ]; then \
+	    echo "[INFO] Copying PAM configuration..."; \
+	    sudo cp misc/waycratelock /etc/pam.d/waycratelock; \
+	    echo "[SUCCESS] PAM configuration set."; \
+	else \
+	    echo "[INFO] PAM configuration already exists, skipping."; \
+	fi
+
+clean:
+	@rm -rf $(BUILD_DIR)
+
+reinstall: clean all setup-pam

--- a/README.md
+++ b/README.md
@@ -13,6 +13,36 @@ WayCrateLock reads configuration from `$XDG_CONFIG_HOME/waycratelock/setting.tom
 
 Here is an example TOML file [setting.toml](./assets/config/setting.toml)
 
+## Building
+
+This project uses a Makefile (wrapper for CMake) that can build targets like so:
+
+```bash
+make # will setup pam and build WayCrateLock locally
+
+make install # for a global install (system wide)
+```
+
+> [!NOTE]
+> 
+> In case you want to manually build **without** Makefile,
+> 
+> Ensure that `misc/waycratelock` file is copied over to your `/etc/pam.d/waycratelock`
+> 
+> Without this, the screenlock will **NEVER** unlock as PAM will continue to fail authenticate you!
+> 
+
+**Building using CMake:**
+
+```bash
+sudo cp misc/waycratelock /etc/pam.d/waycratelock # ENSURE THAT THIS FILE EXISTS IN /etc/pam.d!!
+
+cmake -S . -B build 
+cmake --build build/
+
+./build/waycratelock # to run the binary
+```
+
 ## Help needed
 
 The password text field only can input on the first screen registered, I think the problem is in qt-session-lock, the qt binding for session-lock-v1, but I cannot handle it.

--- a/src/CommandLine.cpp
+++ b/src/CommandLine.cpp
@@ -199,7 +199,7 @@ CommandLine::RequestUnlock()
             break;
         }
         case Failed: {
-            m_errorMessage = "password is error, failed to unlock";
+            m_errorMessage = "Incorrect password given!";
             Q_EMIT errorMessageChanged();
             break;
         }


### PR DESCRIPTION
This commit introduces a Makefile to the project, that can setup pam and build local and global targets. This is necessary as without this, users cannot understand or solve the major problem of the screenlock not unlocking even if they give the right password. The Makefile is simple to run and is highly flexible for future target addition like debug etc.

This also resolves the issue of password falsely being authenticated as incorrect by PAM

The previous CMakeLists line:

```cmake
install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/misc/waycratelock DESTINATION
        ${CMAKE_INSTALL_SYSCONFDIR}/pam.d)
```

This does not work properly as intended as this is an **INSTALL COMMAND**: In case you do not build the application globally with `make install`, **ALL** local builds will result in never being able to exit the lock screen and this is a problem for users who want to try out the lock screen locally, contribute or debug.

Ultimately this is not a problem of session lock qt bindings itself, but the fact that this cmakelists does not work for local builds at all.